### PR TITLE
Sort keys of labels by tier

### DIFF
--- a/src/BrandfolderClient.php
+++ b/src/BrandfolderClient.php
@@ -2593,6 +2593,7 @@ class BrandfolderClient
                 $unique_and_sortable_key = $label->attributes->position . '_' . $label->id;
                 $labels_by_tier[$label->attributes->depth][$unique_and_sortable_key] = $label;
             }
+            ksort($labels_by_tier, SORT_NATURAL);
             foreach ($labels_by_tier as $tier => $labels) {
                 // Sort Labels by position (it's OK if Labels from various parents
                 // are interspersed at this point).


### PR DESCRIPTION
Recently noticed some strange behaviour in labels.

Upon further inspection the ordering of the labels and the structure was a bit off. Once I added the sorting of the keys of the labels by tier the labels were in the same order as before.

This was likely due to the re-ordering of the labels in Brandfolder.

To replicate create a structure similar to this:

- Label 1
   - Label 2
      - Label 3

And then change the order:
- Label 1
   - Label 3
      - Label 2 

The output will not be as expected.